### PR TITLE
Fix broken PHP5 xdebug installation.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -181,7 +181,7 @@ RUN set -xe; \
 		memcache \
 		redis \
 		ssh2 \
-		xdebug \
+		xdebug-2.5.5 \
 	;\
 	docker-php-ext-enable \
 		gnupg \


### PR DESCRIPTION
Installing xdebug without specifiying a version leads to this error:

```
sudo pecl install xdebug
pecl/xdebug requires PHP (version >= 7.0.0), installed version is 5.6.33

```
So i propose to install xdebug-2.5.5 - the last version with php5 support - instead.